### PR TITLE
Restore argument types in integrate function

### DIFF
--- a/src/PCHIPInterpolation.jl
+++ b/src/PCHIPInterpolation.jl
@@ -197,7 +197,7 @@ end
     return _integrate(itp, a, b, _findinterval(itp, a), _findinterval(itp, b))
 end
 
-@inline integrate(itp, a, b) = _integrate(itp, a, b)
+@inline integrate(itp::Interpolator, a::Number, b::Number) = _integrate(itp, a, b)
 
 
 @recipe function _(itp::Interpolator; markershape=:none) \


### PR DESCRIPTION
These were inadvertently removed in #29 