### PR TITLE
Fixed bug in definition of wl and wr terms #31

### DIFF
--- a/src/PCHIPInterpolation.jl
+++ b/src/PCHIPInterpolation.jl
@@ -36,8 +36,8 @@ function _pchip_ds_scipy(xs::AbstractVector, ys::AbstractVector)
             if sign(Δl) != sign(Δr) || Δl ≈ 0.0 || Δr ≈ 0.0
                 ds[i] = 0.0
             else
-                wl = 2hl + hr
-                wr = hl + 2hr
+                wl = 2hr + hl
+                wr = hr + 2hl
                 ds[i] = (wl + wr) / (wl/Δl + wr/Δr)
             end
             Δl = Δr

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,3 +232,14 @@ ys = copy(itp.ys)
 v .= -1
 @test itp.xs == xs
 @test itp.ys == ys
+
+# Test correctness of _pchip_ds_scipy implementation following https://github.com/gerlero/PCHIPInterpolation.jl/issues/31
+# Tests that the interpolated values are the same as SciPy
+xs = [0.0,  1.2,  2.0,  5.0, 10.0, 11.0]
+ys = [2.0,  2.1,  1.0,  0.0,  0.0,  3.0]
+
+xps = [0.6, 1.6, 3.5, 7.5, 10.5]
+yps = [2.08750000, 1.61081474, 0.27194471, 0.00000000, 1.06250000]
+
+itp = @inferred Interpolator(xs, ys)
+@test itp.(xps) ≈ yps atol=1e-8


### PR DESCRIPTION
Definition of wl and wr terms in _pchip_ds_scipy corrected so that the implementation is the same as SciPy.

Test added to ensure that interpolated values are consistent with SciPy.